### PR TITLE
Ignore error when deleting old pkg

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 deps:
-	rm -r pypkgs/
+	rm -rf pypkgs/
 	pip install -t pypkgs -r pypi_deps.txt
-	rm -r pypkgs/*.egg-info
+	rm -rf pypkgs/*.egg-info
 	bower install


### PR DESCRIPTION
If the `pypkgs` directory does not exist, the building fails on first line.
